### PR TITLE
brick & tree prototype

### DIFF
--- a/Proyecto/Prototipos/Brik/RigidBody2D.tscn
+++ b/Proyecto/Prototipos/Brik/RigidBody2D.tscn
@@ -1,0 +1,27 @@
+[gd_scene load_steps=4 format=2]
+
+[ext_resource path="res://icon.png" type="Texture" id=1]
+[ext_resource path="res://Prototipos/Brik/brick.gd" type="Script" id=2]
+
+[sub_resource type="RectangleShape2D" id=1]
+extents = Vector2( 16, 16 )
+
+[node name="StaticBody2D" type="StaticBody2D"]
+script = ExtResource( 2 )
+
+[node name="Node2D" type="Node2D" parent="."]
+
+[node name="icon2" type="Sprite" parent="Node2D"]
+modulate = Color( 0.45098, 0.490196, 0, 1 )
+position = Vector2( 0, 12 )
+scale = Vector2( 0.5, 0.125 )
+texture = ExtResource( 1 )
+
+[node name="icon" type="Sprite" parent="Node2D"]
+modulate = Color( 0.0431373, 0.247059, 0, 1 )
+position = Vector2( 0, -8 )
+scale = Vector2( 0.5, 0.5 )
+texture = ExtResource( 1 )
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = SubResource( 1 )

--- a/Proyecto/Prototipos/Brik/brick.gd
+++ b/Proyecto/Prototipos/Brik/brick.gd
@@ -1,0 +1,10 @@
+extends StaticBody2D
+
+var life = 2
+
+func destroy():
+	life -= 1
+	if life <= 0:
+		queue_free()
+	else:
+		$Node2D.modulate += Color(1,1,1)

--- a/Proyecto/Prototipos/Prototipo.tscn
+++ b/Proyecto/Prototipos/Prototipo.tscn
@@ -1,3 +1,56 @@
-[gd_scene format=2]
+[gd_scene load_steps=8 format=2]
+
+[ext_resource path="res://Prototipos/Tank/Tank.tscn" type="PackedScene" id=1]
+[ext_resource path="res://icon.png" type="Texture" id=2]
+[ext_resource path="res://Prototipos/TileMap.gd" type="Script" id=3]
+[ext_resource path="res://Prototipos/Brik/RigidBody2D.tscn" type="PackedScene" id=4]
+[ext_resource path="res://Prototipos/Tree/Tree.tscn" type="PackedScene" id=5]
+
+[sub_resource type="TileSet" id=1]
+0/name = "icon.png 0"
+0/texture = ExtResource( 2 )
+0/tex_offset = Vector2( 0, 0 )
+0/modulate = Color( 1, 1, 1, 1 )
+0/region = Rect2( 0, 0, 32, 32 )
+0/tile_mode = 0
+0/occluder_offset = Vector2( 0, 0 )
+0/navigation_offset = Vector2( 0, 0 )
+0/shape_offset = Vector2( 0, 0 )
+0/shape_transform = Transform2D( 1, 0, 0, 1, 0, 0 )
+0/shape_one_way = false
+0/shape_one_way_margin = 0.0
+0/shapes = [  ]
+0/z_index = 0
+
+[sub_resource type="RectangleShape2D" id=2]
+extents = Vector2( 30.303, 28.5714 )
 
 [node name="Prototipo" type="Node2D"]
+
+[node name="Tank" parent="." instance=ExtResource( 1 )]
+position = Vector2( 784, 376 )
+
+[node name="Bricks" type="TileMap" parent="."]
+tile_set = SubResource( 1 )
+cell_size = Vector2( 32, 32 )
+format = 1
+tile_data = PoolIntArray( 1, 0, 0, 2, 0, 0, 3, 0, 0, 4, 0, 0, 5, 0, 0, 6, 0, 0, 7, 0, 0, 8, 0, 0, 9, 0, 0, 10, 0, 0, 11, 0, 0, 12, 0, 0, 65537, 0, 0, 65538, 0, 0, 65539, 0, 0, 65540, 0, 0, 65541, 0, 0, 65542, 0, 0, 65543, 0, 0, 65544, 0, 0, 65545, 0, 0, 65546, 0, 0, 65547, 0, 0, 65548, 0, 0, 131073, 0, 0, 131074, 0, 0, 131083, 0, 0, 131084, 0, 0, 196609, 0, 0, 196610, 0, 0, 196619, 0, 0, 196620, 0, 0, 262145, 0, 0, 262146, 0, 0, 262155, 0, 0, 262156, 0, 0, 327681, 0, 0, 327682, 0, 0, 327691, 0, 0, 327692, 0, 0, 393217, 0, 0, 393218, 0, 0, 393221, 0, 0, 393222, 0, 0, 393225, 0, 0, 393226, 0, 0, 393227, 0, 0, 393228, 0, 0, 393229, 0, 0, 393230, 0, 0, 393231, 0, 0, 393232, 0, 0, 393233, 0, 0, 458753, 0, 0, 458754, 0, 0, 458757, 0, 0, 458758, 0, 0, 458761, 0, 0, 458762, 0, 0, 458763, 0, 0, 458764, 0, 0, 458765, 0, 0, 458766, 0, 0, 458767, 0, 0, 458768, 0, 0, 458769, 0, 0, 524289, 0, 0, 524290, 0, 0, 524293, 0, 0, 524294, 0, 0, 524304, 0, 0, 524305, 0, 0, 589825, 0, 0, 589826, 0, 0, 589829, 0, 0, 589830, 0, 0, 589840, 0, 0, 589841, 0, 0, 655361, 0, 0, 655362, 0, 0, 655365, 0, 0, 655366, 0, 0, 655376, 0, 0, 655377, 0, 0, 720897, 0, 0, 720898, 0, 0, 720901, 0, 0, 720902, 0, 0, 720912, 0, 0, 720913, 0, 0, 786433, 0, 0, 786434, 0, 0, 786437, 0, 0, 786438, 0, 0, 786448, 0, 0, 786449, 0, 0, 851969, 0, 0, 851970, 0, 0, 851971, 0, 0, 851972, 0, 0, 851973, 0, 0, 851974, 0, 0, 851975, 0, 0, 851976, 0, 0, 851977, 0, 0, 851978, 0, 0, 851979, 0, 0, 851980, 0, 0, 851981, 0, 0, 851982, 0, 0, 851983, 0, 0, 851984, 0, 0, 851985, 0, 0, 917505, 0, 0, 917506, 0, 0, 917507, 0, 0, 917508, 0, 0, 917509, 0, 0, 917510, 0, 0, 917511, 0, 0, 917512, 0, 0, 917513, 0, 0, 917514, 0, 0, 917515, 0, 0, 917516, 0, 0, 917517, 0, 0, 917518, 0, 0, 917519, 0, 0, 917520, 0, 0, 917521, 0, 0 )
+script = ExtResource( 3 )
+brick = ExtResource( 4 )
+
+[node name="Label" type="Label" parent="."]
+margin_left = 200.0
+margin_top = 120.0
+margin_right = 240.0
+margin_bottom = 134.0
+text = "secret"
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Tree" parent="." instance=ExtResource( 5 )]
+position = Vector2( 224, 128 )
+scale = Vector2( 3.96, 1.96 )
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Tree"]
+shape = SubResource( 2 )

--- a/Proyecto/Prototipos/Tank/Bullet.gd
+++ b/Proyecto/Prototipos/Tank/Bullet.gd
@@ -1,0 +1,16 @@
+extends Area2D
+
+var direction = Vector2.RIGHT
+export var speed = 300
+
+func set_direction(_direction):
+	direction = _direction
+
+func _physics_process(delta):
+	global_position += direction * speed * delta
+
+
+
+func _on_Bullet_body_entered(body):
+	body.destroy()
+	queue_free()

--- a/Proyecto/Prototipos/Tank/Bullet.tscn
+++ b/Proyecto/Prototipos/Tank/Bullet.tscn
@@ -1,0 +1,21 @@
+[gd_scene load_steps=4 format=2]
+
+[ext_resource path="res://icon.png" type="Texture" id=1]
+[ext_resource path="res://Prototipos/Tank/Bullet.gd" type="Script" id=2]
+
+[sub_resource type="RectangleShape2D" id=1]
+extents = Vector2( 8, 8 )
+
+[node name="Bullet" type="Area2D"]
+script = ExtResource( 2 )
+
+[node name="icon" type="Sprite" parent="."]
+self_modulate = Color( 0.513726, 0.0509804, 0.0509804, 1 )
+scale = Vector2( 0.25, 0.25 )
+texture = ExtResource( 1 )
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+visible = false
+shape = SubResource( 1 )
+
+[connection signal="body_entered" from="." to="." method="_on_Bullet_body_entered"]

--- a/Proyecto/Prototipos/Tank/Tank.gd
+++ b/Proyecto/Prototipos/Tank/Tank.gd
@@ -1,0 +1,54 @@
+extends Area2D
+
+export var move_size := 8
+export var bullet : PackedScene
+
+var tile_size = 64
+var moving := false
+onready var ray = $RayCast2D
+
+func _ready():
+	position = position.snapped(Vector2.ONE * tile_size)
+	position += Vector2.ONE * tile_size/2
+	move_size = tile_size/4
+
+func _physics_process(delta):
+	var _dir = Vector2.ZERO
+	
+	if not moving:
+		if Input.is_action_pressed("ui_right"):
+			_move(Vector2.RIGHT)
+			$icon.rotation_degrees = 90
+		if Input.is_action_pressed("ui_left"):
+			_move(Vector2.LEFT)
+			$icon.rotation_degrees = -90
+		if Input.is_action_pressed("ui_down"):
+			_move(Vector2.DOWN)
+			$icon.rotation_degrees = 180
+		if Input.is_action_pressed("ui_up"):
+			_move(Vector2.UP)
+			$icon.rotation_degrees = 0
+	
+	if Input.is_action_just_pressed("ui_accept"):
+		var _new_bullet = bullet.instance()
+		_new_bullet.global_position = $icon/Canon.global_position
+		_new_bullet.set_direction(position.direction_to($icon/Canon.global_position))
+		get_parent().add_child(_new_bullet)
+
+func _move(dir):
+	ray.cast_to = dir * 32
+	ray.force_raycast_update()
+	
+	if ray.is_colliding(): 
+		return
+	moving = true
+	var _time = 0.2
+	var _new_position = position + dir * move_size
+	
+	$Tween.interpolate_property( self, "position",
+								position, _new_position, _time,
+								Tween.TRANS_LINEAR)
+	
+	$Tween.start()
+	yield($Tween, "tween_completed")
+	moving = false

--- a/Proyecto/Prototipos/Tank/Tank.tscn
+++ b/Proyecto/Prototipos/Tank/Tank.tscn
@@ -1,0 +1,29 @@
+[gd_scene load_steps=5 format=2]
+
+[ext_resource path="res://icon.png" type="Texture" id=1]
+[ext_resource path="res://Prototipos/Tank/Tank.gd" type="Script" id=2]
+[ext_resource path="res://Prototipos/Tank/Bullet.tscn" type="PackedScene" id=3]
+
+[sub_resource type="RectangleShape2D" id=1]
+extents = Vector2( 32, 32 )
+
+[node name="Tank" type="Area2D"]
+collision_layer = 2
+collision_mask = 0
+script = ExtResource( 2 )
+bullet = ExtResource( 3 )
+
+[node name="icon" type="Sprite" parent="."]
+modulate = Color( 0.0705882, 0.180392, 0.372549, 1 )
+texture = ExtResource( 1 )
+
+[node name="Canon" type="Position2D" parent="icon"]
+position = Vector2( 0, -32 )
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = SubResource( 1 )
+
+[node name="RayCast2D" type="RayCast2D" parent="."]
+enabled = true
+
+[node name="Tween" type="Tween" parent="."]

--- a/Proyecto/Prototipos/TileMap.gd
+++ b/Proyecto/Prototipos/TileMap.gd
@@ -1,0 +1,16 @@
+extends TileMap
+
+
+export var brick : PackedScene
+var _used_tiles
+
+func _ready():
+	_used_tiles = get_used_cells()
+	spawn_bricks()
+
+func spawn_bricks():
+	for tile in _used_tiles:
+		var _new_brick = brick.instance()
+		_new_brick.global_position = map_to_world(tile) + Vector2(16, 16)
+		add_child(_new_brick)
+		set_cell(tile.x, tile.y, -1)

--- a/Proyecto/Prototipos/Tree/Tree.gd
+++ b/Proyecto/Prototipos/Tree/Tree.gd
@@ -1,0 +1,12 @@
+extends Area2D
+
+
+
+func _on_Tree_area_entered(area):
+	visible = false
+
+
+
+
+func _on_Tree_area_exited(area):
+	visible = true

--- a/Proyecto/Prototipos/Tree/Tree.tscn
+++ b/Proyecto/Prototipos/Tree/Tree.tscn
@@ -1,0 +1,16 @@
+[gd_scene load_steps=3 format=2]
+
+[ext_resource path="res://icon.png" type="Texture" id=1]
+[ext_resource path="res://Prototipos/Tree/Tree.gd" type="Script" id=2]
+
+[node name="Tree" type="Area2D"]
+collision_layer = 0
+collision_mask = 2
+script = ExtResource( 2 )
+
+[node name="icon" type="Sprite" parent="."]
+modulate = Color( 1, 0.960784, 0, 1 )
+texture = ExtResource( 1 )
+
+[connection signal="area_entered" from="." to="." method="_on_Tree_area_entered"]
+[connection signal="area_exited" from="." to="." method="_on_Tree_area_exited"]


### PR DESCRIPTION
Los bloques de ladrillos en realidad son 4 bloques mas pequeños.
Cada bloque tiene 2 de vida.
se puede mover y disparar con el tanque pero el disparo y la movilidad son place holders.
Tambien agrege un "arbol". A diferencia del juego original este no te permite ver nada, y solo se puede ver lo que haya de bajo una vez se entra con el tanque.